### PR TITLE
Set commentstring

### DIFF
--- a/ftplugin/systemd.vim
+++ b/ftplugin/systemd.vim
@@ -1,0 +1,3 @@
+setlocal commentstring="#%s"
+
+let b:undo_ftplugin = "setlocal commentstring<"


### PR DESCRIPTION
Some plugins (The-NERD-Commenter is a good example of this) use
commentstring to know how to comment and uncomment lines, vim also uses
the setting to allow for folding of comments (see :help 'commentstring')
