### PR TITLE
Detect *.target outside of */systemd/* for syntax

### DIFF
--- a/ftdetect/systemd.vim
+++ b/ftdetect/systemd.vim
@@ -1,6 +1,7 @@
 au BufRead,BufNewFile *.service set filetype=systemd
 au BufRead,BufNewFile *.timer set filetype=systemd
 au BufRead,BufNewFile *.mount set filetype=systemd
+au BufRead,BufNewFile *.target set filetype=systemd
 au BufRead,BufNewFile */systemd/*.network set filetype=systemd
 au BufRead,BufNewFile */systemd/*.netdev set filetype=systemd
 au BufRead,BufNewFile */systemd/*.target set filetype=systemd


### PR DESCRIPTION
This commit adds `*.target` to syntax highlighting detection for systemd. This is useful when working on packaging outside of the installed tree of systemd.

It looks like this may have been deliberately ignored to avoid conflicts - but in case it wasn't, this PR makes `*.target` files work as I was hoping!